### PR TITLE
Update base_ro_3gpp.xml

### DIFF
--- a/dictionaries/base_ro_3gpp.xml
+++ b/dictionaries/base_ro_3gpp.xml
@@ -428,7 +428,7 @@
         <setfield name="avp-code" value="423"></setfield>
         <setfield name="flags" value="64"></setfield>
       </define>
-      <define name="Subscription-Id " type="Grouped">
+      <define name="Subscription-Id" type="Grouped">
         <setfield name="avp-code" value="443"></setfield>
         <setfield name="flags" value="64"></setfield>
       </define>


### PR DESCRIPTION
there was a problem with one of the avp definitions, an extra space ' ' was found.
